### PR TITLE
return generic logger from LoggerFilterExample that accepts a class parameter

### DIFF
--- a/src/main/java/io/github/parvez3019/example/LoggerFilterExample.java
+++ b/src/main/java/io/github/parvez3019/example/LoggerFilterExample.java
@@ -39,8 +39,8 @@ public class LoggerFilterExample extends OncePerRequestFilter {
     /**
      * @return will return you the logger instance that can statically imported in your classes.
      */
-    public static Logger Logger() {
-        return requestLogInfoThreadLocal.getLogger();
+    public static org.slf4j.Logger Logger(Class<?> clazz) {
+        return  LoggerFactory.getLogger(clazz);
     }
 
 }


### PR DESCRIPTION
This is done so that when we specify the pattern of our log, we can include the name of the package from which the log message originated.